### PR TITLE
Implement Continuous Integration Pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,9 +8,7 @@
 
 ## Check lists (check x in [ ] of list items)
 For each of these items, please refer to the [software style guide](https://github.com/Autonomous-Motorsports-Purdue/AMP_ASSv2/wiki/Software-Style-Guide)
-- [ ] Test written/updated
-- [ ] Tests passing
+- [ ] Test written/updated and implemented to CI
 - [ ] Logging (where appropriate)
-- [ ] Coding style
 
 ## Any additional comments?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: AMP_ASSv2 CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    name: build
+    runs-on: ubuntu-latest
+    env:
+      DESKTOP_DOCKER: ./docker/desktop.Dockerfile
+      DESKTOP_TAG: amp-devel:noetic-desktop
+      FRAME_DOCKER: ./docker/frame.Dockerfile
+      FRAME_TAG: amp-devel:frame-desktop
+      MESA_DOCKER: ./docker/mesa.Dockerfile
+      MESA_TAG: amp-devel:mesa-desktop
+    steps:
+      - 
+        name: Check Out Repo
+        uses: actions/checkout@v2
+      - 
+        name: Disable zed
+        run: ./disable_zed.sh
+      - 
+        name: Build noetic-desktop
+        run: docker build --file $DESKTOP_DOCKER --tag $DESKTOP_TAG .
+      - 
+        name: Build frame-desktop
+        run: docker build --file $FRAME_DOCKER --tag $FRAME_TAG .
+      - 
+        name: Build mesa-build
+        run: docker build --file $MESA_DOCKER --tag $MESA_TAG .

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,22 @@
+name: AMP-CLI CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Check Out Repo
+        uses: actions/checkout@v2
+      - 
+        name: Build amp-cli
+        run: pip install .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # AMP Autonomous Software Stack v2
+[![AMP-CLI CI](https://github.com/Autonomous-Motorsports-Purdue/AMP_ASSv2/actions/workflows/cli.yml/badge.svg)](https://github.com/Autonomous-Motorsports-Purdue/AMP_ASSv2/actions/workflows/cli.yml)     [![AMP_ASSv2 CI](https://github.com/Autonomous-Motorsports-Purdue/AMP_ASSv2/actions/workflows/ci.yml/badge.svg)](https://github.com/Autonomous-Motorsports-Purdue/AMP_ASSv2/actions/workflows/ci.yml)
 
 Second iteration of the Autonomous Software Stack (ASS) for the AMP go-kart.
 
@@ -21,6 +22,7 @@ Takes MoveBaseGoal and converts them to cmd_vel to the simulated kart
 # Running 
 * To build the amp-cli tool, run:
 ```
-pip install .
+sudo pip install .
 ```
+
 * Run `amp-cli` to view the available options.


### PR DESCRIPTION
## What is a quick description of the change?
Implementation of CI build test

## Is this fixing an issue?
This PR close #6 

## Were any issues created as a result of this change?
None

## Are there more details that are relevant?
An attempt to build the stack directly failed due to the presence of the zed repository. At the time of writing, Dockerfile building is the way building will be tested. However, methods to build the stack directly should be, and will be, explored further. Template for PR modified since tests and code style should be automated down the line.
