### PR TITLE
Add optional launch argument to disable showing Viz windows

### DIFF
--- a/src/rtabmap_manager/launch/rtabmap_manager.launch
+++ b/src/rtabmap_manager/launch/rtabmap_manager.launch
@@ -32,7 +32,8 @@
         </node>
     
         <!-- RTABmapviz -->
-        <node name="rtabmapviz" pkg="rtabmap_ros" type="rtabmapviz" output="screen" args="" launch-prefix="">    
+        <arg name="show_viz" default="true" />
+        <node if="$(arg show_viz)" name="rtabmapviz" pkg="rtabmap_ros" type="rtabmapviz" output="screen" args="" launch-prefix="">
             <remap from="rgb/image"         to="$(arg rgb_topic)"/>
             <remap from="depth/image"       to="$(arg depth_topic)"/>
             <remap from="rgb/camera_info"   to="$(arg camera_info_topic)"/>

--- a/src/zed_host/launch/zed_host.launch
+++ b/src/zed_host/launch/zed_host.launch
@@ -61,7 +61,8 @@
         </node>
 
         <!-- Rviz -->
-        <node name="rviz" pkg="rviz" type="rviz" args="-d $(find zed_host)/rviz/zed_preview.rviz" output="screen" />
+        <arg name="show_viz" default="true" />
+        <node if="$(arg show_viz)" name="rviz" pkg="rviz" type="rviz" args="-d $(find zed_host)/rviz/zed_preview.rviz" output="screen" />
     </group>
 
 </launch>

--- a/src/zed_host/launch/zed_host_fake.launch
+++ b/src/zed_host/launch/zed_host_fake.launch
@@ -6,7 +6,8 @@
 
     <group ns="$(arg camera_name)">
         <!-- Rviz -->
-        <node name="rviz" pkg="rviz" type="rviz" args="-d $(find zed_host)/rviz/zed_preview.rviz" output="screen" /> 
+        <arg name="show_viz" default="true" />
+        <node if="$(arg show_viz)" name="rviz" pkg="rviz" type="rviz" args="-d $(find zed_host)/rviz/zed_preview.rviz" output="screen" />
     </group>
 
 </launch>


### PR DESCRIPTION
## What is a quick description of the change?
The launch files contained in the `rtabmap_manager` and `zed_host` packages can now be used without always showing their respective Viz windows. The default behavior of those launch files remains unchanged.
## Is this fixing an issue?
No
## Were any issues created as a result of this change?
No
## Are there more details that are relevant?
Example command usage: `roslaunch rtabmap_manager rtabmap_manager.launch show_viz:=false`