### PR TITLE
FIX: Removed network host option

### DIFF
--- a/amp_cli.py
+++ b/amp_cli.py
@@ -89,7 +89,6 @@ def devel(build: bool, display: str):
         if display == 'mesa':
             container = client.containers.run(
                 tag, stdin_open=True, tty=True, auto_remove=True,
-                network_mode='host',
                 name='amp-assv2-scratch',
                 environment={
                     'DISPLAY': os.getenv('DISPLAY'),
@@ -215,7 +214,6 @@ def scratch(build: bool, display: str):
         if display == 'mesa':
             container = client.containers.run(
                 tag, stdin_open=True, tty=True, auto_remove=True,
-                network_mode='host',
                 name='amp-assv2-scratch',
                 environment={
                     'DISPLAY': os.getenv('DISPLAY'),


### PR DESCRIPTION
## What is a quick description of the change?
Removed the `host` parameter from the container initialization calls. This is because ROS relies on the localhost configuration to execute and on an Arch Linux system the localhost is set to computer localhost and ROS fails to run

## Is this fixing an issue?
No

## Were any issues created as a result of this change?
No

## Are there more details that are relevant?
None

## Check lists (check x in [ ] of list items)
For each of these items, please refer to the [software style guide](https://github.com/Autonomous-Motorsports-Purdue/AMP_ASSv2/wiki/Software-Style-Guide)
- [ ] Test written/updated and implemented to CI
- [ ] Logging (where appropriate)

## Any additional comments?
